### PR TITLE
Migrate to MPS 2019.3.4

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -34,10 +34,10 @@
         <id>com.dslfoundry.langvis</id>
         <name>com.dslfoundry.langvis</name>
         <description>A JetBrains MPS plugin to visualize the structure of a language</description>
-        <version>2019.2</version>
+        <version>2019.3</version>
         <vendor url="http://dslfoundry.com/">DSLFoundry</vendor>
         <depends>jetbrains.mps.core</depends>
-        <idea-version until-build="193.1" since-build="192.1" />
+        <idea-version until-build="194.1" since-build="193.1" />
         
         <extensions defaultExtensionNs="com.intellij">
           <mps.LanguageLibrary dir="/languages" />

--- a/solutions/mps-langvis.build/models/mps-langvis/build.mps
+++ b/solutions/mps-langvis.build/models/mps-langvis/build.mps
@@ -198,13 +198,13 @@
         <node concept="2pNUuL" id="2aMbqeN3MX5" role="2pNNFR">
           <property role="2pNUuO" value="until-build" />
           <node concept="2pMdtt" id="2aMbqeN3MXg" role="2pMdts">
-            <property role="2pMdty" value="193.1" />
+            <property role="2pMdty" value="194.1" />
           </node>
         </node>
         <node concept="2pNUuL" id="2aMbqeN3MXk" role="2pNNFR">
           <property role="2pNUuO" value="since-build" />
           <node concept="2pMdtt" id="2aMbqeN3MXx" role="2pMdts">
-            <property role="2pMdty" value="192.1" />
+            <property role="2pMdty" value="193.1" />
           </node>
         </node>
       </node>
@@ -215,7 +215,7 @@
       </node>
       <node concept="3_J27D" id="359UCzqDaRK" role="m$_w8">
         <node concept="3Mxwew" id="359UCzqDaRL" role="3MwsjC">
-          <property role="3MwjfP" value="2019.2" />
+          <property role="3MwjfP" value="2019.3" />
         </node>
       </node>
       <node concept="m$f5U" id="359UCzqDaRM" role="m$_yh">


### PR DESCRIPTION
Also update the minimal and maximal idea build versions
Without loading the plugin fails with
    Plugin "com.dslfoundry.langvis"
    is incompatible (target build range is 192.1 to 193.1).

Signed-off-by: Bart vdr. Meulen <bartvdrmeulen@gmail.com>